### PR TITLE
Overriding Variables

### DIFF
--- a/lib/factory_group.rb
+++ b/lib/factory_group.rb
@@ -10,15 +10,15 @@ module FactoryGroup
   end
 
   def self.define(name, &block)
-    FactoryGroup.registry[name] = -> {
-      Group.new.tap{ |g| g.instance_eval(&block) }
-    }
+    FactoryGroup.registry[name] = Proc.new do |overrides|
+      Group.new(overrides).tap{ |g| g.instance_eval(&block) }
+    end
   end
 
-  def self.create(name)
+  def self.create(name, overrides = {})
     raise Exceptions::FactoryGroupNotDefined if !registry[name]
 
-    factory_group = registry[name].call
+    factory_group = registry[name].call(overrides)
     factory_group.factories
   end
 end

--- a/lib/factory_group/group.rb
+++ b/lib/factory_group/group.rb
@@ -4,19 +4,21 @@ require "ostruct"
 module FactoryGroup
   class Group
 
-    def initialize
+    def initialize(overrides = {})
       @factories = OpenStruct.new({})
+      @overrides = overrides
     end
 
-    attr_reader :factories
+    attr_reader :factories, :overrides
 
     # Sets an instance variable with the name as the called method and
     # assigns the args[0] passed to it.
     def method_missing(name, *args, &block)
-      # If the args is empty, it means a variable is reused inside the group itself
-      evaluvated_result = args.empty? ? @factories.instance_eval(name.to_s) : args[0]
+      # If the factory is overridden use it.
+      return @factories.send("#{name.to_s}=", overrides[name]) if overrides[name].present?
 
-      @factories.send("#{name.to_s}=", evaluvated_result)
+      # If the args is empty, it means a variable is reused inside the group itself
+      args.empty? ? @factories.instance_eval(name.to_s) : @factories.send("#{name.to_s}=", args[0])
     end
   end
 end

--- a/spec/acceptance/factory_group_spec.rb
+++ b/spec/acceptance/factory_group_spec.rb
@@ -34,5 +34,36 @@ describe FactoryGroup do
         expect(@user_group.name).to eq "sample"
       end
     end
+
+    describe "with a factory overridden" do
+      before do
+        described_class.define(:user_group) do
+          user FactoryGirl.create(:user)
+        end
+
+        @overriding_user = FactoryGirl.create(:user, :name => "Overridden Name")
+        @user_group = FactoryGroup.create(:user_group, :user => @overriding_user)
+      end
+
+      it "should create the user object with the overridden parameters" do
+        expect(@user_group.user.name).to eq "Overridden Name"
+      end
+    end
+
+    describe "with a factory overridden and used at a later point in time" do
+      before do
+        described_class.define(:user_group) do
+          user FactoryGirl.create(:user)
+          name user.name
+        end
+
+        @overriding_user = FactoryGirl.create(:user, :name => "Overridden Name")
+        @user_group = FactoryGroup.create(:user_group, :user => @overriding_user)
+      end
+
+      it "should use the overridden user object" do
+        expect(@user_group.name).to eq "Overridden Name"
+      end
+    end
   end
 end


### PR DESCRIPTION
Support for overriding variables inside the FactoryGroup while creating it.

Example:

``` ruby
described_class.define(:user_group) do
  user FactoryGirl.create(:user)
end
```

We should be able to do something like the following.

``` ruby
overriding_user = FactoryGirl.create(:user, :name => "Another User")
FactoryGroup.create(:user_group, :user => overriding_user)
```
